### PR TITLE
Add source of feed

### DIFF
--- a/lib/Mojo/Feed.pm
+++ b/lib/Mojo/Feed.pm
@@ -8,6 +8,7 @@ use Mojo::DOM;
 use HTTP::Date;
 
 has body => '';
+has source;
 
 has dom => sub {
   my ($self) = @_;
@@ -94,6 +95,11 @@ The original decoded string of the feed.
 =head2 dom
 
 The parsed feed as <Mojo::DOM> object.
+
+=head2 source
+
+The source of the feed; either a L<Mojo::Path> or L<Mojo::URL> object, or
+undef if the feed source was a string scalar.
 
 =head2  title
 

--- a/lib/Mojo/Feed.pm
+++ b/lib/Mojo/Feed.pm
@@ -8,7 +8,7 @@ use Mojo::DOM;
 use HTTP::Date;
 
 has body => '';
-has source;
+has 'source';
 
 has dom => sub {
   my ($self) = @_;

--- a/lib/Mojo/Feed/Reader.pm
+++ b/lib/Mojo/Feed/Reader.pm
@@ -22,16 +22,18 @@ has charset => 'UTF-8';
 sub parse {
   my ($self, $xml, $charset) = @_;
   my $body;
+  my $source;
   if ($xml) {
     if ($xml =~ /^\</) {
       $body = $xml;
     }
     elsif (-r $xml) {
-      $body = path($xml)->slurp;
+      $source = path($xml);
+      $body   = $source->slurp;
     }
     elsif ($xml =~ /^https?\:/ || (ref $xml && ref $xml eq 'Mojo::URL')) {
-      my $url = ((ref $xml) ? $xml->clone() : Mojo::URL->new($xml));
-      ($body, $charset) = $self->load($url);
+      my $source = ((ref $xml) ? $xml->clone() : Mojo::URL->new($xml));
+      ($body, $charset) = $self->load($source);
     }
     else {
       ...;
@@ -39,7 +41,7 @@ sub parse {
   }
   $charset ||= $self->charset;
   $body = $charset ? decode($charset, $body) // $body : $body;
-  return Mojo::Feed->new(body => $body);
+  return Mojo::Feed->new(body => $body, source => $source);
 }
 
 sub load {

--- a/lib/Mojo/Feed/Reader.pm
+++ b/lib/Mojo/Feed/Reader.pm
@@ -32,7 +32,7 @@ sub parse {
       $body   = $source->slurp;
     }
     elsif ($xml =~ /^https?\:/ || (ref $xml && ref $xml eq 'Mojo::URL')) {
-      my $source = ((ref $xml) ? $xml->clone() : Mojo::URL->new($xml));
+      $source = ((ref $xml) ? $xml->clone() : Mojo::URL->new($xml));
       ($body, $charset) = $self->load($source);
     }
     else {

--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -42,18 +42,21 @@ my $file = File::Spec->catdir( $sample_dir, 'atom.xml' );
 $feed = Mojo::Feed::Reader->new->parse($file);
 isa_ok( $feed, 'Mojo::Feed' );
 is( $feed->title, 'First Weblog', 'title ok' );
+is ( $feed->source, $file , 'source ok' );
 
 # parse a string
 my $str = Mojo::File->new($file)->slurp;
 $feed = Mojo::Feed->new( body => $str);
 isa_ok( $feed, 'Mojo::Feed' );
 is( $feed->title, 'First Weblog', 'title ok' );
+ok ( !$feed->source,'source ok' );
 
 # parse a URL
 $feed =
   Mojo::Feed::Reader->new->ua( $t->app->ua )->parse( Mojo::URL->new("/atom.xml") );
 isa_ok( $feed, 'Mojo::Feed' );
 is( $feed->title, 'First Weblog', 'title ok' );
+is ( $feed->source->path, '/atom.xml' , 'source ok' );
 
 ## Callback and non-blocking no longer supported - how do we make a promise API?
 


### PR DESCRIPTION
I needed to track the original source of the feed for podite. I first just implemented a hash to save this information, but maybe this would be a helpful addition to Mojo::Feed? 