### PR TITLE
Adding a feed-generate capability - test to_hash method

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'Time::Zone', '2.2';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';
+    requires 'Test::Deep', '1.127';
 };
 
 on 'develop' => sub {

--- a/t/02-no-reader.t
+++ b/t/02-no-reader.t
@@ -1,6 +1,7 @@
 use Mojo::Base -strict;
 
 use Test::More;
+use Test::Deep;
 use Test::Mojo;
 use Mojo::URL;
 use Mojo::File qw(path);
@@ -221,6 +222,56 @@ for my $i ( 5, 7, 24 ) {
         $feed_from_url2->items->[$i]->title,
         'encoding check'
     );
+}
+
+my %Hashes = (
+    'atom1-short.xml' => 'Atom 1.0',
+    'rss20.xml' => 'RSS 2.0',
+);
+my $hash_expected = {
+    author => 'Melody',
+    description => 'This is a test weblog.',
+    items => [
+        {
+            author => 'Melody',
+            content => '<p>Hello!</p>',
+            description => 'Hello!...',
+            guid => ignore(),
+            id => 'http://localhost/weblog/2004/05/entry_two.html',
+            link => 'http://localhost/weblog/2004/05/entry_two.html',
+            published => '1085902765',
+            tags => [ 'Travel' ],
+            title => 'Entry Two',
+        },
+        {
+            author => '',
+            content => '<p>This is a test.</p>
+
+<p>Why don\'t you come down to our place for a coffee and a <strong>chat</strong>?</p>',
+            description => 'This is a test. Why don\'t you come down to our place for a coffee and a chat?...',
+            guid => ignore(),
+            id => 'http://localhost/weblog/2004/05/test.html',
+            link => 'http://localhost/weblog/2004/05/test.html',
+            published => '1084086208',
+            tags => [ 'Sports' ],
+            title => 'Test',
+        }
+    ],
+    link => 'http://localhost/weblog/',
+    published => '1085902797',
+    subtitle => '',
+    title => 'First Weblog',
+};
+
+for my $file (sort keys %Hashes) {
+    my $feed_type_expected = $Hashes{$file};
+    my $path = path( $FindBin::Bin, 'samples', $file );
+    my $feed = Mojo::Feed->new(file => $path)
+        or fail "parse feed ($file) returned undef", next;
+    is $feed->feed_type, $feed_type_expected;
+    my $hash_got = $feed->to_hash;
+    cmp_deeply $hash_got, $hash_expected, $file
+        or diag explain $hash_got;
 }
 
 done_testing();

--- a/t/samples/atom1-short.xml
+++ b/t/samples/atom1-short.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-us">
+<title>First Weblog</title>
+<link href="http://localhost/weblog/"/>
+<description>This is a test weblog.</description>
+<rights>Copyright 2004</rights>
+<updated>2004-05-29T23:39:57-08:00</updated>
+<author>Melody</author>
+
+<entry>
+<title>Entry Two</title>
+<summary>Hello!...</summary>
+<content type="xhtml"><![CDATA[<p>Hello!</p>]]></content>
+<link href="http://localhost/weblog/2004/05/entry_two.html"/>
+<author>Melody</author>
+<id>http://localhost/weblog/2004/05/entry_two.html</id>
+<category term="Travel"/>
+<published>2004-05-29T23:39:25-08:00</published>
+</entry>
+
+<entry>
+<title>Test</title>
+<summary>This is a test. Why don&apos;t you come down to our place for a coffee and a chat?...</summary>
+<content type="xhtml"><![CDATA[<p>This is a test.</p>
+
+<p>Why don't you come down to our place for a coffee and a <strong>chat</strong>?</p>]]></content>
+<link href="http://localhost/weblog/2004/05/test.html"/>
+<id>http://localhost/weblog/2004/05/test.html</id>
+<category term="Sports"/>
+<published>2004-05-08T23:03:28-08:00</published>
+</entry>
+
+</feed>


### PR DESCRIPTION
This is the start of the work discussed on IRC earlier. Before I started that, I thought it valuable to test what is already there, since there weren't any tests of the `to_hash` method currently. The `Test::Deep` is to be able to ignore the `guid` key, because there is no way to supply one to an Atom feed.

Arguably the `guid` should go away, since it is adequately represented by the `id`?