### PR TITLE
item hashes require non-whitespace content

### DIFF
--- a/lib/Mojo/Feed/Item.pm
+++ b/lib/Mojo/Feed/Item.pm
@@ -46,7 +46,8 @@ foreach my $k (keys %selector) {
         if ($k eq 'author' && $p->at('name')) {
           return trim $p->at('name')->text;
         }
-        my $text = trim ($p->text || $p->content || '');
+        my ($text) = grep $_, map trim($_), grep $_, $p->text, $p->content;
+        $text ||= '';
         if ($k eq 'published') {
           return str2time($text);
         }

--- a/t/samples/atom1-short.xml
+++ b/t/samples/atom1-short.xml
@@ -10,7 +10,9 @@
 <entry>
 <title>Entry Two</title>
 <summary>Hello!...</summary>
-<content type="xhtml"><![CDATA[<p>Hello!</p>]]></content>
+<content type="xhtml">
+     <p>Hello!</p>
+</content>
 <link href="http://localhost/weblog/2004/05/entry_two.html"/>
 <author>Melody</author>
 <id>http://localhost/weblog/2004/05/entry_two.html</id>


### PR DESCRIPTION
This fixes feeds where the `->text` has a bunch of whitespace, but that is still true so shortcuts to that. This change requires non-whitespace where available.